### PR TITLE
Added velocity control to kinematics node

### DIFF
--- a/packages/dagu_car_dbv2/config/kinematics_node/default.yaml
+++ b/packages/dagu_car_dbv2/config/kinematics_node/default.yaml
@@ -2,10 +2,14 @@ angle_lim: 0.540
 axis_distance: 0.105
 baseline: 0.092
 cog_distance: 0.0525
-gain: 1.0
-k_wheel: 27.0
 limit: 1.0
 omega_max: 8.0
 radius: 0.0318
 trim: 0.0
 v_max: 1.0
+
+# Feed forward part
+k_wheel: 14
+# Feedback part: If velocity is measured, then the speed will be actively controlled
+k_P: 1.0
+k_I: 0.3


### PR DESCRIPTION
The kinematics node now uses encoder data to actively control the velocity of DBV2 to match the velocity requested by `car_cmd` messages.